### PR TITLE
Fixed Logger namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,9 +363,9 @@ use com\zoho\crm\api\SDKConfigBuilder;
 
 use com\zoho\crm\api\dc\USDataCenter;
 
-use com\zoho\crm\api\logger\Logger;
+use com\zoho\api\logger\Logger;
 
-use com\zoho\crm\api\logger\Levels;
+use com\zoho\api\logger\Levels;
 
 class Initialize
 {
@@ -584,9 +584,9 @@ use com\zoho\crm\api\SDKConfigBuilder;
 
 use com\zoho\crm\api\dc\USDataCenter;
 
-use com\zoho\crm\api\logger\Logger;
+use com\zoho\api\logger\Logger;
 
-use com\zoho\crm\api\logger\Levels;
+use com\zoho\api\logger\Levels;
 
 use com\zoho\crm\api\HeaderMap;
 
@@ -716,9 +716,9 @@ use com\zoho\crm\api\SDKConfigBuilder;
 
 use com\zoho\crm\api\dc\USDataCenter;
 
-use com\zoho\crm\api\logger\Logger;
+use com\zoho\api\logger\Logger;
 
-use com\zoho\crm\api\logger\Levels;
+use com\zoho\api\logger\Levels;
 
 use com\zoho\crm\api\record\RecordOperations;
 


### PR DESCRIPTION
The logger failed and threw invalid class error due to incorrect namespace. It is clearly in the [api](https://github.com/zoho/zohocrm-php-sdk/tree/f4772d9d255fd183f4ced45eb81a23f07c9f9f20/src/com/zoho/api/logger) namespace than the **crm/api** namespace.