### PR TITLE
Change package type to lowercase to fix for Composer 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
 	"name" : "zohocrm/php-sdk",
 	"description" : "Zoho CRM API SDK for PHP",
-	"type" : "SDK",
+	"type" : "sdk",
 	"homepage": "https://github.com/zoho/zohocrm-php-sdk",
 	"authors" : [
 		{


### PR DESCRIPTION
As of Composer 2, the package type must conform to the pattern ` ^[a-z0-9-]+$`. Currently you'll get the error

```
  [Composer\Json\JsonValidationException]
  "./composer.json" does not match the expected JSON schema: 
   - type : Does not match the regex pattern ^[a-z0-9-]+$
```

Similar issue: https://github.com/anchorcms/anchor-cms/issues/1330