### PR TITLE
Serialise request array in JSONConverter

### DIFF
--- a/src/com/zoho/crm/api/util/JSONConverter.php
+++ b/src/com/zoho/crm/api/util/JSONConverter.php
@@ -29,7 +29,28 @@ class JSONConverter extends Converter
 
     public function appendToRequest(&$requestBase, $requestObject)
     {
-        $requestBase[CURLOPT_POSTFIELDS] = json_encode($requestObject, JSON_UNESCAPED_UNICODE);
+        $array = $this->serialiseRequestArray($requestObject);
+
+        $requestBase[CURLOPT_POSTFIELDS] = json_encode($array, JSON_UNESCAPED_UNICODE);
+    }
+
+    private function serialiseRequestArray($input)
+    {
+        $output = [];
+
+        foreach ($input as $key => $value) {
+            if ($value instanceof Record) {
+                $value = $value->getKeyValues();
+            }
+
+            if (is_array($value)) {
+                $value = $this->serialiseRequestArray($value);
+            }
+
+            $output[$key] = $value;
+        }
+
+        return $output;
     }
 
     public function formRequest($requestInstance, $pack, $instanceNumber, $memberDetail=null)


### PR DESCRIPTION
There is currently no logic to serialise Record objects when constructing a request. Since the objects have no public properties, they are expressed in JSON as an empty object `{}`.

In order to be able to send object data (key values) within the request, the converter needs to inspect objects and convert to a key value array before running `json_encode`.