### PR TITLE
Add Header Map Parameter to updateRecord and deleteRecord Methods

### DIFF
--- a/src/com/zoho/crm/api/record/RecordOperations.php
+++ b/src/com/zoho/crm/api/record/RecordOperations.php
@@ -61,8 +61,8 @@ class RecordOperations
 		$handlerInstance->setCategoryMethod(Constants::REQUEST_CATEGORY_UPDATE); 
 		$handlerInstance->setContentType('application/json'); 
 		$handlerInstance->setRequest($request); 
-		Utility::getFields($moduleAPIName); 
 		$handlerInstance->setHeader($header_map); 
+		Utility::getFields($moduleAPIName); 
 		$handlerInstance->setModuleAPIName($moduleAPIName); 
 		return $handlerInstance->apiCall(ActionHandler::class, 'application/json'); 
 

--- a/src/com/zoho/crm/api/record/RecordOperations.php
+++ b/src/com/zoho/crm/api/record/RecordOperations.php
@@ -48,7 +48,7 @@ class RecordOperations
 	 * @param BodyWrapper $request An instance of BodyWrapper
 	 * @return APIResponse An instance of APIResponse
 	 */
-	public  function updateRecord(string $id, string $moduleAPIName, BodyWrapper $request, HeaderMap $header_map)
+	public  function updateRecord(string $id, string $moduleAPIName, BodyWrapper $request, HeaderMap $header_map=null)
 	{
 		$handlerInstance=new CommonAPIHandler(); 
 		$apiPath=""; 
@@ -75,7 +75,7 @@ class RecordOperations
 	 * @param ParameterMap $paramInstance An instance of ParameterMap
 	 * @return APIResponse An instance of APIResponse
 	 */
-	public  function deleteRecord(string $id, string $moduleAPIName, ParameterMap $paramInstance=null, HeaderMap $header_map)
+	public  function deleteRecord(string $id, string $moduleAPIName, ParameterMap $paramInstance=null, HeaderMap $header_map=null)
 	{
 		$handlerInstance=new CommonAPIHandler(); 
 		$apiPath=""; 

--- a/src/com/zoho/crm/api/record/RecordOperations.php
+++ b/src/com/zoho/crm/api/record/RecordOperations.php
@@ -48,7 +48,7 @@ class RecordOperations
 	 * @param BodyWrapper $request An instance of BodyWrapper
 	 * @return APIResponse An instance of APIResponse
 	 */
-	public  function updateRecord(string $id, string $moduleAPIName, BodyWrapper $request)
+	public  function updateRecord(string $id, string $moduleAPIName, BodyWrapper $request, HeaderMap $header_map)
 	{
 		$handlerInstance=new CommonAPIHandler(); 
 		$apiPath=""; 
@@ -62,6 +62,7 @@ class RecordOperations
 		$handlerInstance->setContentType('application/json'); 
 		$handlerInstance->setRequest($request); 
 		Utility::getFields($moduleAPIName); 
+		$handlerInstance->setHeader($header_map); 
 		$handlerInstance->setModuleAPIName($moduleAPIName); 
 		return $handlerInstance->apiCall(ActionHandler::class, 'application/json'); 
 
@@ -74,7 +75,7 @@ class RecordOperations
 	 * @param ParameterMap $paramInstance An instance of ParameterMap
 	 * @return APIResponse An instance of APIResponse
 	 */
-	public  function deleteRecord(string $id, string $moduleAPIName, ParameterMap $paramInstance=null)
+	public  function deleteRecord(string $id, string $moduleAPIName, ParameterMap $paramInstance=null, HeaderMap $header_map)
 	{
 		$handlerInstance=new CommonAPIHandler(); 
 		$apiPath=""; 
@@ -86,6 +87,7 @@ class RecordOperations
 		$handlerInstance->setHttpMethod(Constants::REQUEST_METHOD_DELETE); 
 		$handlerInstance->setCategoryMethod(Constants::REQUEST_METHOD_DELETE); 
 		$handlerInstance->setParam($paramInstance); 
+		$handlerInstance->setHeader($header_map); 
 		return $handlerInstance->apiCall(ActionHandler::class, 'application/json'); 
 
 	}


### PR DESCRIPTION
Allows the user to add their own header map to the `deleteRecord` and `updateRecord` calls. This is helpful, for example, in allowing us to use [External ID fields](https://www.zoho.com/crm/developer/docs/api/v2/records-api-ext-id-overview.html) provided by Zoho to update and delete records. Using the External ID field requires that the `X-EXTERNAL` header be passed.