### PR TITLE
Fix PHP deprecation error in SDKException

### DIFF
--- a/src/com/zoho/crm/api/exception/SDKException.php
+++ b/src/com/zoho/crm/api/exception/SDKException.php
@@ -39,7 +39,7 @@ class SDKException extends \Exception
             $this->_message = $cause->getMessage();
         }
         
-        parent::__construct($message);
+        parent::__construct(is_null($message) ? "" : $message);        
     }
     
     /**


### PR DESCRIPTION
Php deprecation error in php 8.1: 
```
PHP Deprecated:  Exception::__construct(): Passing null to parameter #1 ($message) of type string is deprecated in /zohocrm/php-sdk/src/com/zoho/crm/api/exception/SDKException.php on line 42
```