### PR TITLE
Fix typo in CommonAPIHandler.php

### DIFF
--- a/src/com/zoho/crm/api/util/CommonAPIHandler.php
+++ b/src/com/zoho/crm/api/util/CommonAPIHandler.php
@@ -227,7 +227,7 @@ class CommonAPIHandler
         }
         catch(SDKException $e)
         {
-            SDKLogger::severeError(Constants::SET_API_URL_EXCEPTION, $ex);
+            SDKLogger::severeError(Constants::SET_API_URL_EXCEPTION, $e);
                     
             throw $e;
         }


### PR DESCRIPTION
Variable $ex is undefined. Probably you meant $e