### PR TITLE
Fix when path contains 'src'

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,8 +446,6 @@ class Initialize
 
         $pickListValidation = false;
 
-        $enableSSLVerification = true;
-
         $connectionTimeout = 2;
 
         $timeout = 2;
@@ -654,8 +652,6 @@ class MultiThread
 
         $pickListValidation = false;
 
-        $enableSSLVerification = true;
-
         $connectionTimeout = 2;
 
         $timeout = 2;
@@ -672,7 +668,7 @@ class MultiThread
 
         $user2 = new UserSignature("abc2@zoho.eu");
 
-        $token2 = new OAuthToken("clientId2", "clientSecrect2", "REFRESH/GRANT token", TokenType::REFRESH/GRANT);
+        $token2 = new OAuthToken("clientId2", "clientSecrect2", "REFRESH/GRANT token", TokenType.REFRESH/GRANT);
 
         Initializer::switchUser($user2, $environment2, $token2, $sdkConfig);
 
@@ -806,8 +802,6 @@ class Record
         $autoRefreshFields = false;
 
         $pickListValidation = false;
-
-        $enableSSLVerification = true;
 
         $connectionTimeout = 2;
 

--- a/README.md
+++ b/README.md
@@ -446,6 +446,8 @@ class Initialize
 
         $pickListValidation = false;
 
+        $enableSSLVerification = true;
+
         $connectionTimeout = 2;
 
         $timeout = 2;
@@ -652,6 +654,8 @@ class MultiThread
 
         $pickListValidation = false;
 
+        $enableSSLVerification = true;
+
         $connectionTimeout = 2;
 
         $timeout = 2;
@@ -668,7 +672,7 @@ class MultiThread
 
         $user2 = new UserSignature("abc2@zoho.eu");
 
-        $token2 = new OAuthToken("clientId2", "clientSecrect2", "REFRESH/GRANT token", TokenType.REFRESH/GRANT);
+        $token2 = new OAuthToken("clientId2", "clientSecrect2", "REFRESH/GRANT token", TokenType::REFRESH/GRANT);
 
         Initializer::switchUser($user2, $environment2, $token2, $sdkConfig);
 
@@ -802,6 +806,8 @@ class Record
         $autoRefreshFields = false;
 
         $pickListValidation = false;
+
+        $enableSSLVerification = true;
 
         $connectionTimeout = 2;
 

--- a/src/com/zoho/crm/api/Initializer.php
+++ b/src/com/zoho/crm/api/Initializer.php
@@ -122,7 +122,7 @@ class Initializer
             { 
                 if(is_null(self::$jsonDetails))
                 {
-                    self::$jsonDetails = json_decode(file_get_contents(explode("src", realpath(__DIR__))[0] . Constants::JSON_DETAILS_FILE_PATH), true);
+                    self::$jsonDetails = json_decode(file_get_contents(join("src", explode("src", realpath(__DIR__), -1)) . Constants::JSON_DETAILS_FILE_PATH), true);
                 }
             }
             catch (\Exception $ex)

--- a/src/com/zoho/crm/api/Initializer.php
+++ b/src/com/zoho/crm/api/Initializer.php
@@ -122,7 +122,7 @@ class Initializer
             { 
                 if(is_null(self::$jsonDetails))
                 {
-                    self::$jsonDetails = json_decode(file_get_contents(join("src", explode("src", realpath(__DIR__), -1)) . Constants::JSON_DETAILS_FILE_PATH), true);
+                    self::$jsonDetails = json_decode(file_get_contents(explode("src", realpath(__DIR__))[0] . Constants::JSON_DETAILS_FILE_PATH), true);
                 }
             }
             catch (\Exception $ex)

--- a/src/com/zoho/crm/api/util/HeaderParamValidator.php
+++ b/src/com/zoho/crm/api/util/HeaderParamValidator.php
@@ -60,7 +60,7 @@ class HeaderParamValidator
 
         if(is_null($json_Details))
         {
-            $json_Details = json_decode(file_get_contents(explode("src", realpath(__DIR__))[0] . Constants::JSON_DETAILS_FILE_PATH), true);
+            $json_Details = json_decode(file_get_contents(join("src", explode("src", realpath(__DIR__), -1)) . Constants::JSON_DETAILS_FILE_PATH), true);
 
             Initializer::$jsonDetails = $json_Details;
         }

--- a/src/com/zoho/crm/api/util/HeaderParamValidator.php
+++ b/src/com/zoho/crm/api/util/HeaderParamValidator.php
@@ -60,7 +60,7 @@ class HeaderParamValidator
 
         if(is_null($json_Details))
         {
-            $json_Details = json_decode(file_get_contents(join("src", explode("src", realpath(__DIR__), -1)) . Constants::JSON_DETAILS_FILE_PATH), true);
+            $json_Details = json_decode(file_get_contents(explode("src", realpath(__DIR__))[0] . Constants::JSON_DETAILS_FILE_PATH), true);
 
             Initializer::$jsonDetails = $json_Details;
         }


### PR DESCRIPTION
If you run the php-sdk from a path that includes the string "src" it will throw an `SDKException` as it cannot find the JSON details file.

E.g if my code is running from `/home/user/src/project/` (with `/home/user/src/project/vendor/zohocrm/php-sdk/`) I get the following error when I try to call `Initializer::initialize`:

`com\zoho\crm\api\exception\SDKException Caused by : ERROR IN READING JSONDETAILS FILE :  - file_get_contents(/home/user/src/resources/JSONDetails.json): Failed to open stream: No such file or directory`

It should be using the file `/home/user/src/project/vendor/zohocrm/php-sdk/src/resources/JSONDetails.json`.

This PR fixes this issue and works for both paths containing and not containing "src".